### PR TITLE
chore(storybook): fix deploys

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -37,6 +37,8 @@ jobs:
           cache: 'npm'
       - name: Install Node dependencies
         run: npm ci
+      - name: Build Tailwind Styles
+        run: npm run build:css
       - name: Build Storybook Assets
         run: npm run build-storybook
         env:

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test": "jest",
     "storybook": "concurrently \"npm run watch:css\" \"start-storybook -p 6006\"",
     "build-storybook": "build-storybook",
+    "build:css": "npx tailwindcss -i ./src/renderer/app/app.css -o ./src/renderer/app/tailwind.css",
     "watch:css": "npx tailwindcss -i ./src/renderer/app/app.css -o ./src/renderer/app/tailwind.css --watch"
   },
   "lint-staged": {


### PR DESCRIPTION
Closes #28 
The latest deploy to storybook failed because it couldn't find the tailwind css file.
https://github.com/PradaIng/structuraid-desktop/actions/runs/4071179705/jobs/7012740451

Compiling the tailwind styles before doing the storybook build should fix this issue