### PR TITLE
Model Axis System

### DIFF
--- a/src/renderer/constants/routes.ts
+++ b/src/renderer/constants/routes.ts
@@ -7,5 +7,6 @@ export default {
     PROCEDURAL_TEXT: '/modelling-ui-poc/procedural-text',
     UCS: '/modelling-ui-poc/ucs',
     GRID_SYSTEM: '/modelling-ui-poc/grid-system',
+    COLUMNS_2D: '/modelling-ui-poc/columns-2d',
   },
 };

--- a/src/renderer/pages/modelling-ui-poc/columns-2d/columns-2d.tsx
+++ b/src/renderer/pages/modelling-ui-poc/columns-2d/columns-2d.tsx
@@ -1,11 +1,5 @@
 import { useEffect } from 'react';
-import {
-  WebGLRenderer,
-  OrthographicCamera,
-  Scene,
-  Color,
-  Vector2,
-} from 'three';
+import { WebGLRenderer, OrthographicCamera, Scene, Color } from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import invariant from 'tiny-invariant';
 import { InfiniteGrid, ModelGrid } from 'renderer/three/components';

--- a/src/renderer/pages/modelling-ui-poc/columns-2d/columns-2d.tsx
+++ b/src/renderer/pages/modelling-ui-poc/columns-2d/columns-2d.tsx
@@ -1,0 +1,97 @@
+import { useEffect } from 'react';
+import { WebGLRenderer, OrthographicCamera, Scene, Color } from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+import invariant from 'tiny-invariant';
+import { InfiniteGrid, ModelAxisLabel } from 'renderer/three/components';
+import { CSS3DRenderer } from 'three/examples/jsm/renderers/CSS3DRenderer';
+import { COLORS } from 'renderer/constants';
+
+const Columns2D = () => {
+  useEffect(() => {
+    const webglContainerEl = document.querySelector('.webgl-wrapper');
+    invariant(webglContainerEl, 'could not find container tag');
+
+    const renderer = new WebGLRenderer({ alpha: true });
+    renderer.setSize(
+      webglContainerEl.clientWidth,
+      webglContainerEl.clientHeight
+    );
+
+    webglContainerEl.appendChild(renderer.domElement);
+
+    const cssContainerEl = document.querySelector('.css-wrapper');
+    invariant(cssContainerEl, 'could not find container tag');
+
+    const cssRenderer = new CSS3DRenderer();
+    cssRenderer.setSize(
+      cssContainerEl.clientWidth,
+      cssContainerEl.clientHeight
+    );
+
+    cssContainerEl.appendChild(cssRenderer.domElement);
+
+    const camera = new OrthographicCamera(
+      -webglContainerEl.clientWidth / 2,
+      webglContainerEl.clientWidth / 2,
+      webglContainerEl.clientHeight / 2,
+      -webglContainerEl.clientHeight / 2,
+      0.1,
+      1000
+    );
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    const cssControls = new OrbitControls(camera, cssRenderer.domElement);
+
+    controls.enableRotate = false;
+    cssControls.enableRotate = false;
+
+    camera.position.set(0, 0, 10);
+    controls.update();
+    cssControls.update();
+
+    const scene = new Scene();
+    scene.background = new Color(COLORS.BLACK);
+
+    const grid = new InfiniteGrid({
+      spacingX: 10,
+      spacingY: 10,
+      color: new Color(COLORS.DARK),
+      distance: 2000,
+    });
+
+    grid.position.set(0, 0, -0.0001); // little tweak to make sure the grid stays behind all objects
+
+    scene.add(grid);
+
+    const axisLabel = new ModelAxisLabel({
+      label: 'A',
+      containerEl: cssContainerEl,
+    });
+
+    scene.add(axisLabel.object3D);
+
+    function animate() {
+      requestAnimationFrame(animate);
+
+      controls.update();
+      cssControls.update();
+
+      cssRenderer.render(scene, camera);
+      renderer.render(scene, camera);
+    }
+    animate();
+  }, []);
+
+  return (
+    <div className="p-20 min-h-screen">
+      <h1 className="font-bold text-blue-500 text-6xl mb-6">2D Columns</h1>
+
+      <div className="canvas-wrapper h-screen relative">
+        <div className="css-wrapper w-full h-screen absolute left-0 top-0 z-10" />
+        <div className="webgl-wrapper w-full h-screen absolute left-0 top-0 z-0" />
+      </div>
+    </div>
+  );
+};
+
+export default Columns2D;

--- a/src/renderer/pages/modelling-ui-poc/columns-2d/columns-2d.tsx
+++ b/src/renderer/pages/modelling-ui-poc/columns-2d/columns-2d.tsx
@@ -8,7 +8,7 @@ import {
 } from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import invariant from 'tiny-invariant';
-import { InfiniteGrid, ModelAxis } from 'renderer/three/components';
+import { InfiniteGrid, ModelGrid } from 'renderer/three/components';
 import { CSS3DRenderer } from 'three/examples/jsm/renderers/CSS3DRenderer';
 import { COLORS } from 'renderer/constants';
 
@@ -69,25 +69,41 @@ const Columns2D = () => {
 
     scene.add(grid);
 
-    const axisLabelX = new ModelAxis({
-      label: 'A',
-      direction: 'x',
-      startPosition: new Vector2(10, 10),
-      endPosition: new Vector2(200, 10),
+    const modelGrid = new ModelGrid({
+      disposition: {
+        x: [
+          {
+            label: 'A',
+            coordinate: 0,
+          },
+          {
+            label: 'B',
+            coordinate: 12.5,
+          },
+          {
+            label: 'C',
+            coordinate: 17.5,
+          },
+        ],
+        y: [
+          {
+            label: '1',
+            coordinate: 0,
+          },
+          {
+            label: '2',
+            coordinate: 7.5,
+          },
+          {
+            label: '3',
+            coordinate: 15,
+          },
+        ],
+      },
       containerEl: cssContainerEl,
     });
 
-    scene.add(axisLabelX.object3D);
-
-    const axisLabelY = new ModelAxis({
-      label: '1',
-      direction: 'y',
-      startPosition: new Vector2(20, 0),
-      endPosition: new Vector2(20, 200),
-      containerEl: cssContainerEl,
-    });
-
-    scene.add(axisLabelY.object3D);
+    scene.add(modelGrid.object3D);
 
     function animate() {
       requestAnimationFrame(animate);

--- a/src/renderer/pages/modelling-ui-poc/columns-2d/columns-2d.tsx
+++ b/src/renderer/pages/modelling-ui-poc/columns-2d/columns-2d.tsx
@@ -1,8 +1,14 @@
 import { useEffect } from 'react';
-import { WebGLRenderer, OrthographicCamera, Scene, Color } from 'three';
+import {
+  WebGLRenderer,
+  OrthographicCamera,
+  Scene,
+  Color,
+  Vector2,
+} from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import invariant from 'tiny-invariant';
-import { InfiniteGrid, ModelAxisLabel } from 'renderer/three/components';
+import { InfiniteGrid, ModelAxis } from 'renderer/three/components';
 import { CSS3DRenderer } from 'three/examples/jsm/renderers/CSS3DRenderer';
 import { COLORS } from 'renderer/constants';
 
@@ -63,12 +69,25 @@ const Columns2D = () => {
 
     scene.add(grid);
 
-    const axisLabel = new ModelAxisLabel({
+    const axisLabelX = new ModelAxis({
       label: 'A',
+      direction: 'x',
+      startPosition: new Vector2(10, 10),
+      endPosition: new Vector2(200, 10),
       containerEl: cssContainerEl,
     });
 
-    scene.add(axisLabel.object3D);
+    scene.add(axisLabelX.object3D);
+
+    const axisLabelY = new ModelAxis({
+      label: '1',
+      direction: 'y',
+      startPosition: new Vector2(20, 0),
+      endPosition: new Vector2(20, 200),
+      containerEl: cssContainerEl,
+    });
+
+    scene.add(axisLabelY.object3D);
 
     function animate() {
       requestAnimationFrame(animate);

--- a/src/renderer/pages/modelling-ui-poc/columns-2d/index.ts
+++ b/src/renderer/pages/modelling-ui-poc/columns-2d/index.ts
@@ -1,0 +1,1 @@
+export { default } from './columns-2d';

--- a/src/renderer/pages/modelling-ui-poc/grid-system/grid-system.tsx
+++ b/src/renderer/pages/modelling-ui-poc/grid-system/grid-system.tsx
@@ -3,7 +3,6 @@ import { WebGLRenderer, PerspectiveCamera, Scene, Color } from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import invariant from 'tiny-invariant';
 import { InfiniteGrid } from 'renderer/three/components';
-import { CSS3DRenderer } from 'three/examples/jsm/renderers/CSS3DRenderer';
 import { COLORS } from 'renderer/constants';
 
 const GridSystem = () => {
@@ -19,17 +18,6 @@ const GridSystem = () => {
 
     webglContainerEl.appendChild(renderer.domElement);
 
-    const cssContainerEl = document.querySelector('.css-wrapper');
-    invariant(cssContainerEl, 'could not find container tag');
-
-    const cssRenderer = new CSS3DRenderer();
-    cssRenderer.setSize(
-      cssContainerEl.clientWidth,
-      cssContainerEl.clientHeight
-    );
-
-    cssContainerEl.appendChild(cssRenderer.domElement);
-
     const camera = new PerspectiveCamera(
       75,
       webglContainerEl.clientWidth / webglContainerEl.clientHeight,
@@ -38,12 +26,10 @@ const GridSystem = () => {
     );
 
     const controls = new OrbitControls(camera, renderer.domElement);
-    const cssControls = new OrbitControls(camera, cssRenderer.domElement);
 
     camera.position.set(100, 100, 100);
     camera.lookAt(0, 0, 0);
     controls.update();
-    cssControls.update();
 
     const scene = new Scene();
     scene.background = new Color(COLORS.BLACK);
@@ -61,9 +47,7 @@ const GridSystem = () => {
       requestAnimationFrame(animate);
 
       controls.update();
-      cssControls.update();
 
-      cssRenderer.render(scene, camera);
       renderer.render(scene, camera);
     }
     animate();
@@ -74,7 +58,6 @@ const GridSystem = () => {
       <h1 className="font-bold text-blue-500 text-6xl mb-6">Grid System</h1>
 
       <div className="canvas-wrapper h-screen relative">
-        <div className="css-wrapper w-full h-screen absolute left-0 top-0 z-10" />
         <div className="webgl-wrapper w-full h-screen absolute left-0 top-0 z-0" />
       </div>
     </div>

--- a/src/renderer/pages/modelling-ui-poc/index.ts
+++ b/src/renderer/pages/modelling-ui-poc/index.ts
@@ -6,3 +6,4 @@ export { default as DrawingLines } from './drawing-lines';
 export { default as ProceduralText } from './procedural-text';
 export { default as GridSystem } from './grid-system';
 export { default as Ucs } from './ucs';
+export { default as Columns2D } from './columns-2d';

--- a/src/renderer/pages/modelling-ui-poc/modelling-ui-poc.tsx
+++ b/src/renderer/pages/modelling-ui-poc/modelling-ui-poc.tsx
@@ -41,6 +41,12 @@ const ModellingUiPoc = () => {
         >
           Grid System
         </Link>
+        <Link
+          to={ROUTES.MODELLING_UI_POC.COLUMNS_2D}
+          className="font-bold text-xl hover:text-blue-500 transition-all"
+        >
+          2D Columns
+        </Link>
       </ul>
     </div>
   );

--- a/src/renderer/routes/app-router/app-router.tsx
+++ b/src/renderer/routes/app-router/app-router.tsx
@@ -7,13 +7,14 @@ import {
   ProceduralText,
   GridSystem,
   Ucs,
+  Columns2D,
 } from 'renderer/pages/modelling-ui-poc';
 
 const AppRouter = () => {
   return (
     <Router>
       <Routes>
-        <Route path={ROUTES.ROOT} element={<Home />} />
+        <Route path={ROUTES.ROOT} element={<Columns2D />} />
         <Route
           path={ROUTES.MODELLING_UI_POC.ROOT}
           element={<ModellingUiPoc />}
@@ -34,6 +35,10 @@ const AppRouter = () => {
         <Route
           path={ROUTES.MODELLING_UI_POC.GRID_SYSTEM}
           element={<GridSystem />}
+        />
+        <Route
+          path={ROUTES.MODELLING_UI_POC.COLUMNS_2D}
+          element={<Columns2D />}
         />
       </Routes>
     </Router>

--- a/src/renderer/routes/app-router/app-router.tsx
+++ b/src/renderer/routes/app-router/app-router.tsx
@@ -14,7 +14,7 @@ const AppRouter = () => {
   return (
     <Router>
       <Routes>
-        <Route path={ROUTES.ROOT} element={<Columns2D />} />
+        <Route path={ROUTES.ROOT} element={<Home />} />
         <Route
           path={ROUTES.MODELLING_UI_POC.ROOT}
           element={<ModellingUiPoc />}

--- a/src/renderer/three/components/index.ts
+++ b/src/renderer/three/components/index.ts
@@ -7,3 +7,4 @@ export { default as UCS } from './ucs';
 export { default as InfiniteGrid } from './infinte-grid';
 export { default as ModelAxisLabel } from './model-axis-label';
 export { default as ModelAxis } from './model-axis';
+export { default as ModelGrid } from './model-grid';

--- a/src/renderer/three/components/index.ts
+++ b/src/renderer/three/components/index.ts
@@ -5,3 +5,4 @@ export { default as ZAxis } from './z-axis';
 export { default as XAxis } from './x-axis';
 export { default as UCS } from './ucs';
 export { default as InfiniteGrid } from './infinte-grid';
+export { default as ModelAxisLabel } from './model-axis-label';

--- a/src/renderer/three/components/index.ts
+++ b/src/renderer/three/components/index.ts
@@ -6,3 +6,4 @@ export { default as XAxis } from './x-axis';
 export { default as UCS } from './ucs';
 export { default as InfiniteGrid } from './infinte-grid';
 export { default as ModelAxisLabel } from './model-axis-label';
+export { default as ModelAxis } from './model-axis';

--- a/src/renderer/three/components/model-axis-label/index.ts
+++ b/src/renderer/three/components/model-axis-label/index.ts
@@ -1,0 +1,1 @@
+export { default } from './model-axis-label';

--- a/src/renderer/three/components/model-axis-label/model-axis-label.ts
+++ b/src/renderer/three/components/model-axis-label/model-axis-label.ts
@@ -1,0 +1,64 @@
+import { CircleGeometry, Mesh, MeshBasicMaterial, Group } from 'three';
+import { CSS3DObject } from 'three/examples/jsm/renderers/CSS3DRenderer';
+import { COLORS } from 'renderer/constants';
+
+import type { Object3D } from 'three';
+import type { ModelAxisLabelOptions } from './types';
+
+const CIRCLE_RADIUS = 10;
+const CIRCLE_SEGMENTS = 32;
+
+class ModelAxisLabel {
+  public label: string;
+
+  public object3D: Object3D;
+
+  #circle: Mesh;
+
+  #labelObj: CSS3DObject;
+
+  constructor({ label, containerEl }: ModelAxisLabelOptions) {
+    this.label = label;
+
+    this.#circle = ModelAxisLabel.#buildCircle();
+    this.#labelObj = ModelAxisLabel.#buildLabelObj(this.label, containerEl);
+    this.object3D = this.#build3DObject();
+  }
+
+  // update({ camera }: ModelAxisLabelUpdateOptions) {}
+
+  #build3DObject() {
+    const group = new Group();
+
+    group.add(this.#circle);
+    group.add(this.#labelObj);
+
+    return group;
+  }
+
+  static #buildCircle() {
+    const geometry = new CircleGeometry(CIRCLE_RADIUS, CIRCLE_SEGMENTS);
+    const material = new MeshBasicMaterial({ color: COLORS.WHITE });
+
+    const circle = new Mesh(geometry, material);
+    return circle;
+  }
+
+  static #buildLabelObj(label: string, containerEl: Element) {
+    const labelEl = document.createElement('div');
+    labelEl.style.fontSize = '1rem';
+    labelEl.style.color = COLORS.BLACK;
+    labelEl.textContent = label;
+
+    containerEl.appendChild(labelEl);
+
+    const labelObject = new CSS3DObject(labelEl);
+    labelObject.position.x = 0;
+    labelObject.position.y = 0;
+    labelObject.position.z = 0;
+
+    return labelObject;
+  }
+}
+
+export default ModelAxisLabel;

--- a/src/renderer/three/components/model-axis-label/model-axis-label.ts
+++ b/src/renderer/three/components/model-axis-label/model-axis-label.ts
@@ -5,8 +5,8 @@ import { COLORS } from 'renderer/constants';
 import type { Object3D, Vector2 } from 'three';
 import type { ModelAxisLabelOptions } from './types';
 
-export const LABEL_SIZE = 10;
-const LABEL_FONT_SIZE = '0.5rem';
+export const LABEL_SIZE = 5;
+const LABEL_FONT_SIZE = '0.25rem';
 const CIRCLE_SEGMENTS = 32;
 
 class ModelAxisLabel {

--- a/src/renderer/three/components/model-axis-label/model-axis-label.ts
+++ b/src/renderer/three/components/model-axis-label/model-axis-label.ts
@@ -2,14 +2,17 @@ import { CircleGeometry, Mesh, MeshBasicMaterial, Group } from 'three';
 import { CSS3DObject } from 'three/examples/jsm/renderers/CSS3DRenderer';
 import { COLORS } from 'renderer/constants';
 
-import type { Object3D } from 'three';
+import type { Object3D, Vector2 } from 'three';
 import type { ModelAxisLabelOptions } from './types';
 
-const CIRCLE_RADIUS = 10;
+export const LABEL_SIZE = 10;
+const LABEL_FONT_SIZE = '0.5rem';
 const CIRCLE_SEGMENTS = 32;
 
 class ModelAxisLabel {
   public label: string;
+
+  public position: Vector2;
 
   public object3D: Object3D;
 
@@ -17,11 +20,16 @@ class ModelAxisLabel {
 
   #labelObj: CSS3DObject;
 
-  constructor({ label, containerEl }: ModelAxisLabelOptions) {
+  constructor({ label, position, containerEl }: ModelAxisLabelOptions) {
     this.label = label;
+    this.position = position;
 
-    this.#circle = ModelAxisLabel.#buildCircle();
-    this.#labelObj = ModelAxisLabel.#buildLabelObj(this.label, containerEl);
+    this.#circle = ModelAxisLabel.#buildCircle(this.position);
+    this.#labelObj = ModelAxisLabel.#buildLabelObj(
+      this.label,
+      this.position,
+      containerEl
+    );
     this.object3D = this.#build3DObject();
   }
 
@@ -36,20 +44,24 @@ class ModelAxisLabel {
     return group;
   }
 
-  static #buildCircle() {
-    const geometry = new CircleGeometry(CIRCLE_RADIUS, CIRCLE_SEGMENTS);
+  static #buildCircle(position: Vector2) {
+    const geometry = new CircleGeometry(LABEL_SIZE / 2, CIRCLE_SEGMENTS);
     const material = new MeshBasicMaterial({ color: COLORS.GRAY2 });
 
     const circle = new Mesh(geometry, material);
 
-    circle.position.set(10, 10, 0);
+    circle.position.set(position.x, position.y, 0);
 
     return circle;
   }
 
-  static #buildLabelObj(label: string, containerEl: Element) {
+  static #buildLabelObj(
+    label: string,
+    position: Vector2,
+    containerEl: Element
+  ) {
     const labelEl = document.createElement('div');
-    labelEl.style.fontSize = '1rem';
+    labelEl.style.fontSize = LABEL_FONT_SIZE;
     labelEl.style.color = COLORS.BLACK;
     labelEl.textContent = label;
 
@@ -57,7 +69,7 @@ class ModelAxisLabel {
 
     const labelObject = new CSS3DObject(labelEl);
 
-    labelObject.position.set(10, 10, 0);
+    labelObject.position.set(position.x, position.y, 0);
 
     return labelObject;
   }

--- a/src/renderer/three/components/model-axis-label/model-axis-label.ts
+++ b/src/renderer/three/components/model-axis-label/model-axis-label.ts
@@ -38,9 +38,12 @@ class ModelAxisLabel {
 
   static #buildCircle() {
     const geometry = new CircleGeometry(CIRCLE_RADIUS, CIRCLE_SEGMENTS);
-    const material = new MeshBasicMaterial({ color: COLORS.WHITE });
+    const material = new MeshBasicMaterial({ color: COLORS.GRAY2 });
 
     const circle = new Mesh(geometry, material);
+
+    circle.position.set(10, 10, 0);
+
     return circle;
   }
 
@@ -53,9 +56,8 @@ class ModelAxisLabel {
     containerEl.appendChild(labelEl);
 
     const labelObject = new CSS3DObject(labelEl);
-    labelObject.position.x = 0;
-    labelObject.position.y = 0;
-    labelObject.position.z = 0;
+
+    labelObject.position.set(10, 10, 0);
 
     return labelObject;
   }

--- a/src/renderer/three/components/model-axis-label/model-axis-label.ts
+++ b/src/renderer/three/components/model-axis-label/model-axis-label.ts
@@ -33,8 +33,6 @@ class ModelAxisLabel {
     this.object3D = this.#build3DObject();
   }
 
-  // update({ camera }: ModelAxisLabelUpdateOptions) {}
-
   #build3DObject() {
     const group = new Group();
 
@@ -46,7 +44,7 @@ class ModelAxisLabel {
 
   static #buildCircle(position: Vector2) {
     const geometry = new CircleGeometry(LABEL_SIZE / 2, CIRCLE_SEGMENTS);
-    const material = new MeshBasicMaterial({ color: COLORS.GRAY2 });
+    const material = new MeshBasicMaterial({ color: COLORS.GRAY40 });
 
     const circle = new Mesh(geometry, material);
 

--- a/src/renderer/three/components/model-axis-label/types.ts
+++ b/src/renderer/three/components/model-axis-label/types.ts
@@ -1,4 +1,7 @@
+import type { Vector2 } from 'three';
+
 export interface ModelAxisLabelOptions {
   label: string;
+  position: Vector2;
   containerEl: Element;
 }

--- a/src/renderer/three/components/model-axis-label/types.ts
+++ b/src/renderer/three/components/model-axis-label/types.ts
@@ -1,0 +1,4 @@
+export interface ModelAxisLabelOptions {
+  label: string;
+  containerEl: Element;
+}

--- a/src/renderer/three/components/model-axis/index.ts
+++ b/src/renderer/three/components/model-axis/index.ts
@@ -1,0 +1,1 @@
+export { default } from './model-axis';

--- a/src/renderer/three/components/model-axis/model-axis.ts
+++ b/src/renderer/three/components/model-axis/model-axis.ts
@@ -100,7 +100,7 @@ class ModelAxis {
       startPosition,
       endPosition,
     ]);
-    const material = new LineBasicMaterial({ color: COLORS.GRAY2 });
+    const material = new LineBasicMaterial({ color: COLORS.GRAY40 });
 
     const line = new Line(geometry, material);
     return line;

--- a/src/renderer/three/components/model-axis/model-axis.ts
+++ b/src/renderer/three/components/model-axis/model-axis.ts
@@ -1,0 +1,110 @@
+import { Line, LineBasicMaterial, BufferGeometry, Group, Vector2 } from 'three';
+import { COLORS } from 'renderer/constants';
+import { ModelAxisLabel } from 'renderer/three/components';
+import { LABEL_SIZE } from 'renderer/three/components/model-axis-label/model-axis-label';
+
+import type { Object3D } from 'three';
+import type { ModelAxisOptions } from './types';
+
+class ModelAxis {
+  public object3D: Object3D;
+
+  #startAxisLabel: ModelAxisLabel;
+
+  #endAxisLabel: ModelAxisLabel;
+
+  #line: Line;
+
+  constructor({
+    label,
+    direction,
+    startPosition,
+    endPosition,
+    containerEl,
+  }: ModelAxisOptions) {
+    this.#startAxisLabel = ModelAxis.#buildStartLabel(
+      label,
+      direction,
+      startPosition,
+      containerEl
+    );
+    this.#endAxisLabel = ModelAxis.#buildEndLabel(
+      label,
+      direction,
+      endPosition,
+      containerEl
+    );
+    this.#line = ModelAxis.#buildLine(startPosition, endPosition);
+
+    this.object3D = this.#build3DObject();
+  }
+
+  // update({ camera }: ModelAxisUpdateOptions) {}
+
+  #build3DObject() {
+    const group = new Group();
+
+    group.add(this.#startAxisLabel.object3D);
+    group.add(this.#endAxisLabel.object3D);
+    group.add(this.#line);
+
+    return group;
+  }
+
+  static #buildStartLabel(
+    label: string,
+    direction: 'x' | 'y',
+    position: Vector2,
+    containerEl: Element
+  ) {
+    const labelPosition = new Vector2(position.x, position.y);
+    if (direction === 'x') {
+      labelPosition.x -= LABEL_SIZE / 2;
+    } else if (direction === 'y') {
+      labelPosition.y -= LABEL_SIZE / 2;
+    }
+
+    const labelObj = new ModelAxisLabel({
+      label,
+      position: labelPosition,
+      containerEl,
+    });
+
+    return labelObj;
+  }
+
+  static #buildEndLabel(
+    label: string,
+    direction: 'x' | 'y',
+    position: Vector2,
+    containerEl: Element
+  ) {
+    const labelPosition = new Vector2(position.x, position.y);
+    if (direction === 'x') {
+      labelPosition.x += LABEL_SIZE / 2;
+    } else if (direction === 'y') {
+      labelPosition.y += LABEL_SIZE / 2;
+    }
+
+    const labelObj = new ModelAxisLabel({
+      label,
+      position: labelPosition,
+      containerEl,
+    });
+
+    return labelObj;
+  }
+
+  static #buildLine(startPosition: Vector2, endPosition: Vector2) {
+    const geometry = new BufferGeometry().setFromPoints([
+      startPosition,
+      endPosition,
+    ]);
+    const material = new LineBasicMaterial({ color: COLORS.GRAY2 });
+
+    const line = new Line(geometry, material);
+    return line;
+  }
+}
+
+export default ModelAxis;

--- a/src/renderer/three/components/model-axis/types.ts
+++ b/src/renderer/three/components/model-axis/types.ts
@@ -1,0 +1,9 @@
+import type { Vector2 } from 'three';
+
+export interface ModelAxisOptions {
+  label: string;
+  direction: 'x' | 'y';
+  startPosition: Vector2;
+  endPosition: Vector2;
+  containerEl: Element;
+}

--- a/src/renderer/three/components/model-grid/index.ts
+++ b/src/renderer/three/components/model-grid/index.ts
@@ -1,0 +1,1 @@
+export { default } from './model-grid';

--- a/src/renderer/three/components/model-grid/model-grid.ts
+++ b/src/renderer/three/components/model-grid/model-grid.ts
@@ -1,0 +1,97 @@
+import { Group, Vector2 } from 'three';
+import { ModelAxis } from 'renderer/three/components';
+// import { LABEL_SIZE } from 'renderer/three/components/model-axis-label/model-axis-label';
+
+import type { Object3D } from 'three';
+import type { ModelAxesDisposition, ModelGridOptions } from './types';
+
+const LABELS_PADDING = 10;
+
+class ModelGrid {
+  public object3D: Object3D;
+
+  #xAxes: ModelAxis[];
+
+  #yAxes: ModelAxis[];
+
+  constructor({ disposition, containerEl }: ModelGridOptions) {
+    this.#xAxes = ModelGrid.#buildXAxes(disposition, containerEl);
+    this.#yAxes = ModelGrid.#buildYAxes(disposition, containerEl);
+
+    this.object3D = this.#build3DObject();
+  }
+
+  #build3DObject() {
+    const group = new Group();
+
+    this.#xAxes.forEach((xAxis) => {
+      group.add(xAxis.object3D);
+    });
+
+    this.#yAxes.forEach((yAxis) => {
+      group.add(yAxis.object3D);
+    });
+
+    return group;
+  }
+
+  static #buildXAxes(disposition: ModelAxesDisposition, containerEl: Element) {
+    const yCoordinates = disposition.y.map(
+      (yDisposition) => yDisposition.coordinate
+    );
+    const yMinCoordinate = Math.min(...yCoordinates);
+    const yMaxCoordinate = Math.max(...yCoordinates);
+
+    const xAxes: ModelAxis[] = [];
+    disposition.x.forEach((xDisposition) => {
+      const axis = new ModelAxis({
+        label: xDisposition.label,
+        direction: 'x',
+        startPosition: new Vector2(
+          yMinCoordinate - LABELS_PADDING,
+          xDisposition.coordinate
+        ),
+        endPosition: new Vector2(
+          yMaxCoordinate + LABELS_PADDING,
+          xDisposition.coordinate
+        ),
+        containerEl,
+      });
+
+      xAxes.push(axis);
+    });
+
+    return xAxes;
+  }
+
+  static #buildYAxes(disposition: ModelAxesDisposition, containerEl: Element) {
+    const xCoordinates = disposition.x.map(
+      (xDisposition) => xDisposition.coordinate
+    );
+    const xMinCoordinate = Math.min(...xCoordinates);
+    const xMaxCoordinate = Math.max(...xCoordinates);
+
+    const yAxes: ModelAxis[] = [];
+    disposition.y.forEach((yDisposition) => {
+      const axis = new ModelAxis({
+        label: yDisposition.label,
+        direction: 'y',
+        startPosition: new Vector2(
+          yDisposition.coordinate,
+          xMinCoordinate - LABELS_PADDING
+        ),
+        endPosition: new Vector2(
+          yDisposition.coordinate,
+          xMaxCoordinate + LABELS_PADDING
+        ),
+        containerEl,
+      });
+
+      yAxes.push(axis);
+    });
+
+    return yAxes;
+  }
+}
+
+export default ModelGrid;

--- a/src/renderer/three/components/model-grid/types.ts
+++ b/src/renderer/three/components/model-grid/types.ts
@@ -1,0 +1,14 @@
+export interface AxisDisposition {
+  label: string;
+  coordinate: number;
+}
+
+export interface ModelAxesDisposition {
+  x: AxisDisposition[];
+  y: AxisDisposition[];
+}
+
+export interface ModelGridOptions {
+  disposition: ModelAxesDisposition;
+  containerEl: Element;
+}


### PR DESCRIPTION
Closes #10 

This PR implements some Three.js components to render a building construction axis in plan view (only for the horizontal/XY plane).

![image](https://user-images.githubusercontent.com/27536621/218346475-39b5cded-0ada-4956-a2fe-f040ccdca543.png)

It must be used like this
```typescript
    const modelGrid = new ModelGrid({
      disposition: {
        x: [
          {
            label: 'A',
            coordinate: 0,
          },
          {
            label: 'B',
            coordinate: 12.5,
          },
          {
            label: 'C',
            coordinate: 17.5,
          },
        ],
        y: [
          {
            label: '1',
            coordinate: 0,
          },
          {
            label: '2',
            coordinate: 7.5,
          },
          {
            label: '3',
            coordinate: 15,
          },
        ],
      },
      containerEl: cssContainerEl,
    });

    scene.add(modelGrid.object3D);
```

I built this in a new PoC page, and cleaned up the grid-system one a bit, removing some stuff that's not being used.